### PR TITLE
Update README.md to reflect unsupported old readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A password-protected card will be automatically locked after power reset. To per
    - Transcend Embedded SD SDC460T / SDC400I / SDC240T
 
 3. Supported Card Reader
-   - Transcend RDF5
+   - Transcend RDF5 produced after 2019
 
 ## Compile the executable file
 


### PR DESCRIPTION
According to the commend on #2, only RDF5 readers produced after 2019 are supported.